### PR TITLE
Disable test PyPI publishing and pre-release checks

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -20,7 +20,6 @@ env:
 
 jobs:
   build:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     outputs:
@@ -68,6 +67,8 @@ jobs:
           echo version="$(poetry version --short)" >> $GITHUB_OUTPUT
 
   test-pypi-publish:
+    # Disable test PyPI publishing for now.
+    if: false
     needs:
       - build
     uses:
@@ -78,6 +79,8 @@ jobs:
     secrets: inherit
 
   pre-release-checks:
+    # Disable pre-release checks for now.
+    if: false
     needs:
       - build
       - test-pypi-publish
@@ -184,8 +187,8 @@ jobs:
   publish:
     needs:
       - build
-      - test-pypi-publish
-      - pre-release-checks
+      # - test-pypi-publish
+      # - pre-release-checks
     runs-on: ubuntu-latest
     permissions:
       # This permission is used for trusted publishing:

--- a/libs/kuzu/pyproject.toml
+++ b/libs/kuzu/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-kuzu"
-version = "0.1.0"
+version = "0.0.1.dev1"
 description = "An integration package connecting Kùzu, an embedded graph database, and LangChain"
 authors = ["prrao87", "mewim"]
 readme = "README.md"


### PR DESCRIPTION
This PR disables test PyPI publishing and pre-release checks for now for simplicity. This makes the publishing pipeline publish directly to the main PyPI index. Since we are doing manual publishing, we can publishing a dev build before publishing the actual release (by simply modify the version number). We can decide later if we would like to re-enable pre-release checks.