### PR TITLE
Update prompt to allow for lowercase matching

### DIFF
--- a/libs/kuzu/langchain_kuzu/chains/graph_qa/prompts.py
+++ b/libs/kuzu/langchain_kuzu/chains/graph_qa/prompts.py
@@ -43,7 +43,7 @@ CYPHER_QA_PROMPT = PromptTemplate(
 KUZU_EXTRA_INSTRUCTIONS = """
 Instructions:
 Generate the Kùzu dialect of Cypher with the following rules in mind:
-1. Do not omit the relationship pattern. Always use `()-[]->()` instead of `()->()`.
+1. When matching on a property, use the `LOWER()` function to match the property value.
 2. Do not include triple backticks ``` in your response. Return only Cypher.
 3. Do not return any notes or comments in your response.
 \n"""

--- a/libs/kuzu/pyproject.toml
+++ b/libs/kuzu/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-kuzu"
-version = "0.2.0"
+version = "0.3.0"
 description = "An integration package connecting Kùzu, an embedded graph database, and LangChain"
 authors = ["prrao87", "mewim"]
 readme = "README.md"


### PR DESCRIPTION
The old prompt didn't consider the case of matching on lowercase property values (e.g., "radium" should be matched as well as "Radium"). The updated prompt asks the LLM to consider using the `LOWER()` function in Kùzu Cypher to match on the lowercased property value. This increases the chances of obtaining a match on more queries on average.

**Note**: We do not need the old prompt statement `Always use ()-[]->()` instead of `()->()` because LLMs by and large do not generate Cypher this way.